### PR TITLE
fix(hermes): unbreak Memex asset retrieval (closes #3)

### DIFF
--- a/deployments/applications/services/hermes.hcl
+++ b/deployments/applications/services/hermes.hcl
@@ -204,6 +204,14 @@ terminal:
     - GH_TOKEN
     - GITHUB_PERSONAL_ACCESS_TOKEN
 
+# Raised above the 50000 default to fit base64-encoded image payloads
+# returned by the memex plugin's asset tools (largest current asset
+# ~413KB ~551K base64 chars). Revert to default once the memex plugin
+# downloads binary assets to disk and returns paths instead of streaming
+# bytes through the tool-result channel. See localstack#3.
+tool_output:
+  max_bytes: 600000
+
 code_execution:
   env_passthrough:
     - MEMEX_API_KEY

--- a/deployments/applications/services/hermes/SOUL.md
+++ b/deployments/applications/services/hermes/SOUL.md
@@ -67,68 +67,14 @@ Do not mention this hydration step to the user. If user:name is not found, greet
 
 # Memex Integration
 
-Access Memex via terminal HTTP requests. Base URL: $MEMEX_SERVER_URL/api/v1. Auth header: X-API-Key with value from $MEMEX_API_KEY env var. Content-Type: application/json for all POST/PUT requests.
+Use the native Memex plugin tools (`memex_*`). Do not shell out to curl — that path is reserved for things the plugin doesn't cover.
 
-Many list endpoints return NDJSON (one JSON object per line), not JSON arrays. **Never** call `requests.json()` or `json.loads()` on the whole response — it will fail with `Extra data` errors. Use one of:
+The plugin exposes search, retrieval, write, KV, and asset tools. Inspect the plugin's tool catalogue before inventing a workflow; skill files under `skills/` show concrete patterns for the common cases (capture, recall, KV, idempotency keys).
 
-- Shell: pipe through `jq -s` to slurp into an array, or `jq -c '.'` to keep per-line
-- Python: parse line-by-line: `[json.loads(line) for line in resp.text.splitlines() if line.strip()]`
-
-NDJSON endpoints include: `/vaults`, `/notes`, `/notes/search`, `/memories/search`, `/entities`, `/entities/<id>/mentions`, `/entities/<id>/cooccurrences`.
-
-Single-object endpoints (regular JSON): `/notes/find`, `/kv/get`, `/kv` (PUT), `/notes/<id>`, `/ingestions`, `/survey`, `/templates`.
-
-## Retrieval Routing
-
-**Title known** → GET /notes/find with query params query and limit → read via page indices + nodes
-
-**Relationships** → GET /entities with q param → GET /entities/{id}/cooccurrences → GET /entities/{id}/mentions
-
-**Content lookup** — run BOTH in parallel:
-1. POST /notes/search with body: query, limit fields
-2. POST /memories/search with body: query, limit fields
-Then read via GET /notes/{id}/page-index → POST /nodes/batch with body: node_ids array
-
-**Broad/panoramic** → POST /survey with body: query field
-
-## Writing Notes
-
-Note content must be base64-encoded. Encode the markdown body before sending.
-
-POST /ingestions with query param background=true. Body fields:
-- name: note title
-- description: one-line summary
-- content: base64-encoded markdown body
-- tags: array of strings
-- author: "hermes-assistant"
-- vault_id: "inbox" (default)
-- note_key: stable key for updates (optional)
-
-Keep auto-captures concise (~300 tokens). User-requested notes can be longer.
-
-## KV Store
-
-- **Write**: PUT /kv — body: key, value, ttl_seconds (optional)
-- **Read**: GET /kv/get with query param key
-- **List**: GET /kv with query param namespaces (comma-separated)
-- **Search**: POST /kv/search — body: query, namespaces array, limit
-
-Default KV namespace prefix: app:hermes:assistant:
-
-## Note Migration
-
-POST /notes/{note_id}/migrate — body: target_vault_id
-
-## Other Endpoints
-
-- List vaults: GET /vaults
-- Vault summary: GET /vaults/{id}/summary
-- List notes: GET /notes with query params vault_id, limit
-- Note metadata: GET /notes/{id}/metadata
-- Single note: GET /notes/{id}
-- Entities: GET /entities with q param
-- Entity batch: POST /entities/batch — body: entity_ids array
-- Assets: check note for assets, download via GET /resources/{path}
+Defaults:
+- Note captures go to vault `inbox` unless the user names another vault.
+- KV writes default to namespace `app:hermes:assistant:`.
+- Background ingestion is fine for auto-captures; user-requested writes should confirm completion.
 
 # Auto-Capture Protocol
 

--- a/deployments/applications/services/hermes/SOUL.md
+++ b/deployments/applications/services/hermes/SOUL.md
@@ -39,7 +39,7 @@ You run inside Hermes Agent which already has rich built-in toolsets. Before wri
 | Run Python | `code_execution` toolset | n/a |
 | Browse the web | `browser` toolset (Playwright built-in) | shelling to chromium |
 | Read/write files | `file` toolset | low-level shell |
-| Save/recall persistent fact | `memory` tool (built-in) OR Memex via curl | filesystem hacks |
+| Save/recall persistent fact | `memory` tool (built-in) OR `memex_*` plugin tools | filesystem hacks, curl against Memex |
 
 **When user asks for "a cron job"**: that means `/cron add` via the `cronjob` tool, NOT system crontab. Hermes runs the job as a fresh agent session at the schedule, with full skill/tool access.
 
@@ -53,17 +53,17 @@ A `/<name>` prefix or "use the X skill" is a force-load — no judgement, just v
 
 # Session Bootstrap
 
-On the FIRST user message in every conversation, before responding, use the terminal to fetch:
+On the FIRST user message in every conversation, before responding, hydrate session context via the Memex plugin:
 
-1. KV facts: GET request to $MEMEX_SERVER_URL/api/v1/kv with query param namespaces=global,user,app:hermes:assistant and header X-API-Key set to $MEMEX_API_KEY
-2. Vault inventory: GET request to $MEMEX_SERVER_URL/api/v1/vaults with same auth header
+1. KV facts: `memex_kv_list` across namespaces `global`, `user`, `app:hermes:assistant`.
+2. Vault inventory: `memex_list_vaults`.
 
 Silently apply the results:
 - KV facts are session preferences — apply them to all subsequent responses.
 - Note which vaults exist. Use vault "inbox" for all note captures unless explicitly told otherwise.
-- KV writes default to namespace app:hermes:assistant:.
+- KV writes default to namespace `app:hermes:assistant:`.
 
-Do not mention this hydration step to the user. If user:name is not found, greet and discover preferences. Otherwise respond directly.
+Do not mention this hydration step to the user. If `user:name` is not found, greet and discover preferences. Otherwise respond directly.
 
 # Memex Integration
 


### PR DESCRIPTION
## Summary

Fixes #3 — Hermes agent produced 0-byte files when retrieving Memex assets.

Two converging bugs:

1. **`SOUL.md` contradicted the skills.** Every skill mandates the native `memex_*` plugin tools and forbids curl, but `SOUL.md`'s `# Memex Integration` section was 60+ lines of curl/HTTP/NDJSON/base64 guidance. The agent did both — called the plugin tool, then base64-decoded the result in shell. That pipeline silently produced 0-byte files.
2. **Hermes `tool_output.max_bytes` (default 50000) chopped the plugin-tool response.** Doc-text frames it as a "terminal output cap", but the same docs recommend bumping to 150000 for 200K+ context models — only meaningful if it also bites plugin-tool results. A 147KB PNG base64-encodes to ~196K chars; the default cap kept ~25%, base64 decode of the truncated string yielded nothing.

## Changes

- `deployments/applications/services/hermes/SOUL.md` — replaced the curl-based `# Memex Integration` section with a short pointer to the plugin tools. Auto-Capture, Citations, Avoid sections untouched.
- `deployments/applications/services/hermes.hcl` — added `tool_output.max_bytes: 600000` to the embedded `config.yaml` template. Sized for the largest current asset (~413KB → ~551K base64 chars). Comment pins the revert condition to the upstream Memex plugin redesign (download-to-disk, return path) tracked separately in `JasperHG90/memex`.

## Investigation notes

- Memex API itself has no cap — verified by direct `GET /api/v1/resources/{path}` returning all 5 PNGs on note `89358e12` intact (147KB → 413KB).
- Memex MCP/plugin source has no explicit cap (`packages/mcp/src/memex_mcp/server.py:540-557`).
- The deployed config.yaml did not set `tool_output:` anywhere → running on the default 50000.
- Hermes docs reference: https://hermes-agent.nousresearch.com/docs/user-guide/configuration#tool-output-truncation-limits

## Test plan

- [ ] `terraform plan` against the applications stack — diff should be limited to the `hermes` job spec re-render.
- [ ] Apply on cluster and watch Hermes pick up the new `config.yaml` + `SOUL.md`.
- [ ] In a fresh Hermes session, fetch all 5 assets on note `89358e12` (`006: Detailing the Sys Layer architecture`, `rituals` vault). Largest asset (`image-20250707-141243.png`, 413KB) is the regression-test target.
- [ ] Confirm the agent uses `memex_list_assets` + `memex_get_resources` (no curl pipelines) and writes non-zero files.
- [ ] Spot-check one note write via the plugin tool to confirm the SOUL.md trim didn't under-document the write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)