### PR TITLE
revert(hermes): drop tool_output.max_bytes (wrong knob)

### DIFF
--- a/deployments/applications/services/hermes.hcl
+++ b/deployments/applications/services/hermes.hcl
@@ -204,14 +204,6 @@ terminal:
     - GH_TOKEN
     - GITHUB_PERSONAL_ACCESS_TOKEN
 
-# Raised above the 50000 default to fit base64-encoded image payloads
-# returned by the memex plugin's asset tools (largest current asset
-# ~413KB ~551K base64 chars). Revert to default once the memex plugin
-# downloads binary assets to disk and returns paths instead of streaming
-# bytes through the tool-result channel. See localstack#3.
-tool_output:
-  max_bytes: 600000
-
 code_execution:
   env_passthrough:
     - MEMEX_API_KEY


### PR DESCRIPTION
## Summary

Reverts the `tool_output.max_bytes: 600000` block added in #4. End-to-end testing showed it had no effect on the asset-retrieval bug it was meant to address.

## Why the bump was wrong

Hermes has 3 layers of tool-result truncation (see `/opt/hermes/tools/tool_result_storage.py`). `tool_output.max_bytes` controls the *terminal-output* path. Plugin-tool results go through a *different* layer: `maybe_persist_tool_result` → `_write_to_sandbox`, which builds:

```python
cmd = f"mkdir -p {dir} && cat > {path} << '{marker}'\n{content}\n{marker}"
env.execute(cmd)   # → subprocess.run(["bash", "-c", cmd], ...)
```

The full content is inlined into the cmd string and passed as a single argv element. argv+envp must fit under `ARG_MAX` (2MB). Reproduced inside the running container with a 550K payload:

```
cmd length: 550,119 chars
ARG_MAX: 2,097,152
OSError: [Errno 7] Argument list too long: 'bash'
```

`_write_to_sandbox` returns `False`, the agent only sees a 1500-char preview + the marker `[Truncated: tool response was N chars. Full output could not be saved to sandbox.]`, and writes 0-byte files. Bumping `tool_output.max_bytes` never touches that code path.

## What stays

The SOUL.md cleanups from #4 remain — they resolved a real contradiction with the skill files (skills said "use plugin tools, not curl"; SOUL.md said the opposite) and stand on their own merits, independent of asset retrieval.

## What's in flight upstream

The asset-retrieval fix is being addressed in the memex plugin itself (download to disk, return a path instead of streaming bytes through the tool-result channel), which sidesteps Hermes' persistence machinery entirely.

## Test plan

- [ ] `terraform plan` — diff limited to the hermes Nomad job re-render.
- [ ] Apply on cluster.
- [ ] Confirm Hermes config.yaml no longer has `tool_output:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)