### PR TITLE
feat(observability): Grafana unified alerting with Telegram

### DIFF
--- a/deployments/infrastructure/services.tf
+++ b/deployments/infrastructure/services.tf
@@ -297,6 +297,10 @@ resource "nomad_job" "grafana" {
     {
       grafana_secret             = vault_kv_secret_v2.grafana_admin_credentials.path
       cluster_overview_dashboard = file("${path.module}/services/grafana/cluster-overview.json")
+      alert_rules                = file("${path.module}/services/grafana/alert-rules.yaml")
+      telegram_secret            = "${var.secret_mount}/data/default/grafana/telegram"
+      telegram_alert_chat_id     = var.telegram_alert_chat_id
+      grafana_external_url       = "http://192.168.2.47:3000"
     }
   )
   depends_on = [nomad_dynamic_host_volume.grafana_data]

--- a/deployments/infrastructure/services/grafana.hcl
+++ b/deployments/infrastructure/services/grafana.hcl
@@ -52,6 +52,10 @@ job "grafana" {
           "local/provisioning/datasources/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro",
           "local/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro",
           "local/dashboards:/etc/grafana/dashboards:ro",
+          "local/provisioning/alerting/contactpoints.yaml:/etc/grafana/provisioning/alerting/contactpoints.yaml:ro",
+          "local/provisioning/alerting/policies.yaml:/etc/grafana/provisioning/alerting/policies.yaml:ro",
+          "local/provisioning/alerting/templates.yaml:/etc/grafana/provisioning/alerting/templates.yaml:ro",
+          "local/provisioning/alerting/rules.yaml:/etc/grafana/provisioning/alerting/rules.yaml:ro",
         ]
       }
 
@@ -63,9 +67,11 @@ job "grafana" {
       env {
         GF_SECURITY_ADMIN_USER         = "admin"
         GF_SERVER_HTTP_PORT            = "3000"
+        GF_SERVER_ROOT_URL             = "http://192.168.2.47:3000"
         GF_USERS_ALLOW_SIGN_UP         = "false"
         GF_ANALYTICS_REPORTING_ENABLED = "false"
         GF_ANALYTICS_CHECK_FOR_UPDATES = "false"
+        GF_UNIFIED_ALERTING_ENABLED    = "true"
       }
 
       template {
@@ -128,6 +134,102 @@ job "grafana" {
         EOF
 
         destination = "local/dashboards/cluster-overview.json"
+      }
+
+      # ---- Unified alerting: contact point (Telegram) ----
+      template {
+        data = <<-EOF
+        apiVersion: 1
+        contactPoints:
+          - orgId: 1
+            name: telegram-default
+            receivers:
+              - uid: telegram-default
+                type: telegram
+                disableResolveMessage: false
+                settings:
+                  bottoken: '{{ with secret "${telegram_secret}" }}{{ .Data.data.bot_token }}{{ end }}'
+                  chatid: "${telegram_alert_chat_id}"
+                  parse_mode: HTML
+                  message: |
+                    {{`{{ template "telegram.message" . }}`}}
+        EOF
+
+        destination = "local/provisioning/alerting/contactpoints.yaml"
+        change_mode = "restart"
+      }
+
+      # ---- Unified alerting: notification policy ----
+      template {
+        data = <<-EOF
+        apiVersion: 1
+        policies:
+          - orgId: 1
+            receiver: telegram-default
+            group_by: [alertname, severity, instance]
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 4h
+            routes:
+              - receiver: telegram-default
+                matchers:
+                  - severity = critical
+                group_wait: 10s
+                group_interval: 2m
+                repeat_interval: 30m
+              - receiver: telegram-default
+                matchers:
+                  - severity = warning
+                group_wait: 1m
+                group_interval: 10m
+                repeat_interval: 4h
+        EOF
+
+        destination = "local/provisioning/alerting/policies.yaml"
+        change_mode = "restart"
+      }
+
+      # ---- Unified alerting: message template ----
+      template {
+        data = <<-EOF
+        apiVersion: 1
+        templates:
+          - orgId: 1
+            name: telegram.message
+            template: |
+              {{`{{ define "telegram.message" }}`}}
+              {{`{{ range .Alerts }}`}}
+              {{`{{ if eq .Status "firing" }}`}}<b>{{`{{ if eq .Labels.severity "critical" }}`}}CRITICAL 🔥{{`{{ else }}`}}WARNING ⚠️{{`{{ end }}`}}</b>
+              {{`{{ else }}`}}<b>RESOLVED ✅</b>
+              {{`{{ end }}`}}
+              <b>Alert:</b> {{`{{ .Labels.alertname }}`}}
+              <b>Instance:</b> <code>{{`{{ .Labels.instance }}`}}</code>
+              <b>Component:</b> {{`{{ .Labels.component }}`}}
+              <b>Summary:</b> {{`{{ .Annotations.summary }}`}}
+              <b>Detail:</b> {{`{{ .Annotations.description }}`}}
+              <a href="${grafana_external_url}/alerting/list">Open Grafana</a>
+              {{`{{ end }}`}}
+              {{`{{ end }}`}}
+        EOF
+
+        destination = "local/provisioning/alerting/templates.yaml"
+        change_mode = "restart"
+      }
+
+      # ---- Unified alerting: rules ----
+      template {
+        # Custom delimiters so consul-template doesn't try to interpret
+        # Grafana's {{ $labels.* }} templating syntax in the rule annotations.
+        # Placeholder is at column 0 (not indented) so the substituted YAML
+        # keeps its native indentation across the first line.
+        left_delimiter  = "<<<<"
+        right_delimiter = ">>>>"
+        data            = <<-EOF
+${alert_rules}
+        EOF
+
+        destination = "local/provisioning/alerting/rules.yaml"
+        change_mode = "restart"
       }
 
       resources {

--- a/deployments/infrastructure/services/grafana/alert-rules.yaml
+++ b/deployments/infrastructure/services/grafana/alert-rules.yaml
@@ -1,0 +1,401 @@
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: cluster-health
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: alert-node-down
+        title: NodeDown
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'up{job="node"} == 0'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: Alerting
+        execErrState: Error
+        for: 5m
+        labels: { severity: critical, component: node }
+        annotations:
+          summary: "Node {{ $labels.instance }} is DOWN"
+          description: "node-exporter on {{ $labels.instance }} unreachable for 5m. Check power, network, ufw, systemd unit."
+
+      - uid: alert-nomad-blocked-evals
+        title: NomadBlockedEvaluations
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'nomad_nomad_blocked_evals_total_blocked'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        labels: { severity: warning, component: nomad }
+        annotations:
+          summary: "Nomad has {{ $value }} blocked evaluations"
+          description: "Scheduler can't place allocs (resource exhaustion, constraints, missing host volumes). Run `nomad eval list -status=blocked`."
+
+      - uid: alert-nomad-server-down
+        title: NomadServerDown
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'up{job="nomad"} == 0'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: Alerting
+        execErrState: Error
+        for: 5m
+        labels: { severity: critical, component: nomad }
+        annotations:
+          summary: "Nomad server on firebat unreachable"
+          description: "Cluster control plane is down. Inspect `systemctl status nomad` on firebat."
+
+      - uid: alert-consul-down
+        title: ConsulDown
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'up{job="consul"} == 0'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: Alerting
+        execErrState: Error
+        for: 5m
+        labels: { severity: critical, component: consul }
+        annotations:
+          summary: "Consul on firebat unreachable"
+          description: "Service discovery + Vault auth depend on this. Check the consul agent."
+
+      - uid: alert-postgres-down
+        title: PostgresDown
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'pg_up == 0'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels: { severity: critical, component: postgres }
+        annotations:
+          summary: "Postgres on firebat is unreachable"
+          description: "postgres_exporter pg_up=0 for 5m. Check postgres alloc, port 5432, disk on firebat."
+
+      - uid: alert-minio-degraded
+        title: MinIOClusterDegraded
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'minio_cluster_nodes_offline_total > 0 or absent(minio_cluster_nodes_online_total)'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels: { severity: critical, component: minio }
+        annotations:
+          summary: "MinIO degraded on orangepi4a"
+          description: "Offline nodes reported or metrics absent. Check MinIO alloc + minio_data host volume."
+
+      - uid: alert-haproxy-down
+        title: HAProxyDown
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'absent(haproxy_process_start_time_seconds)'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: Alerting
+        execErrState: Error
+        for: 5m
+        labels: { severity: critical, component: haproxy }
+        annotations:
+          summary: "HAProxy on firebat appears down"
+          description: "Stats endpoint (8404) unreachable for 5m — ingress is broken."
+
+      - uid: alert-prometheus-down
+        title: PrometheusDown
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'up{job="prometheus"} == 0'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: Alerting
+        execErrState: Error
+        for: 3m
+        labels: { severity: critical, component: prometheus }
+        annotations:
+          summary: "Prometheus is not scraping itself"
+          description: "If you see this, alerting is also at risk. Check Prometheus alloc on ubuntu."
+
+      - uid: alert-node-cpu-high
+        title: NodeCPUHigh
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: '100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle",job="node"}[5m]))) > 90'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 15m
+        labels: { severity: warning, component: node }
+        annotations:
+          summary: "{{ $labels.instance }} CPU > 90% (sustained)"
+          description: "5m avg CPU on {{ $labels.instance }} = {{ printf \"%.1f\" $values.A.Value }}% for 15m."
+
+      - uid: alert-node-mem-high
+        title: NodeMemoryHigh
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: '100 * (1 - node_memory_MemAvailable_bytes{job="node"} / node_memory_MemTotal_bytes{job="node"}) > 90'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 10m
+        labels: { severity: warning, component: node }
+        annotations:
+          summary: "{{ $labels.instance }} memory > 90%"
+          description: "Available memory below 10% on {{ $labels.instance }} for 10m. Usage: {{ printf \"%.1f\" $values.A.Value }}%."
+
+      - uid: alert-node-disk-low
+        title: NodeDiskLow
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: '100 * (node_filesystem_avail_bytes{job="node",fstype!~"tmpfs|overlay|squashfs"} / node_filesystem_size_bytes{job="node",fstype!~"tmpfs|overlay|squashfs"}) < 10'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 15m
+        labels: { severity: warning, component: node }
+        annotations:
+          summary: "{{ $labels.instance }} {{ $labels.mountpoint }} < 10% free"
+          description: "Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} has {{ printf \"%.1f\" $values.A.Value }}% free."
+
+      - uid: alert-memex-log-errors
+        title: MemexLogErrorBurst
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: loki
+            model:
+              expr: 'sum(count_over_time({job="nomad", task="memex"} |~ "(?i)\\b(error|exception|traceback|panic)\\b" [5m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [20] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 10m
+        labels: { severity: warning, component: memex }
+        annotations:
+          summary: "Memex log error burst"
+          description: ">20 error-like log lines in 5m, sustained 10m. Inspect Memex alloc logs."

--- a/deployments/infrastructure/services/grafana/alert-rules.yaml
+++ b/deployments/infrastructure/services/grafana/alert-rules.yaml
@@ -30,7 +30,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: Alerting
+        noDataState: OK
         execErrState: Error
         for: 5m
         labels: { severity: critical, component: node }
@@ -47,7 +47,7 @@ groups:
             datasourceUid: prometheus
             model:
               editorMode: code
-              expr: 'nomad_nomad_blocked_evals_total_blocked'
+              expr: 'sum(nomad_client_allocations_blocked)'
               instant: true
               refId: A
           - refId: C
@@ -63,7 +63,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: NoData
+        noDataState: OK
         execErrState: Error
         for: 10m
         labels: { severity: warning, component: nomad }
@@ -96,7 +96,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: Alerting
+        noDataState: OK
         execErrState: Error
         for: 5m
         labels: { severity: critical, component: nomad }
@@ -129,7 +129,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: Alerting
+        noDataState: OK
         execErrState: Error
         for: 5m
         labels: { severity: critical, component: consul }
@@ -162,7 +162,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: NoData
+        noDataState: OK
         execErrState: Error
         for: 5m
         labels: { severity: critical, component: postgres }
@@ -195,7 +195,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: NoData
+        noDataState: OK
         execErrState: Error
         for: 5m
         labels: { severity: critical, component: minio }
@@ -228,7 +228,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: Alerting
+        noDataState: OK
         execErrState: Error
         for: 5m
         labels: { severity: critical, component: haproxy }
@@ -261,7 +261,7 @@ groups:
                   query: { params: [C] }
                   reducer: { type: last, params: [] }
                   type: query
-        noDataState: Alerting
+        noDataState: OK
         execErrState: Error
         for: 3m
         labels: { severity: critical, component: prometheus }
@@ -311,7 +311,7 @@ groups:
             datasourceUid: prometheus
             model:
               editorMode: code
-              expr: '100 * (1 - node_memory_MemAvailable_bytes{job="node"} / node_memory_MemTotal_bytes{job="node"}) > 90'
+              expr: '100 * (1 - node_memory_MemAvailable_bytes{job="node"} / node_memory_MemTotal_bytes{job="node"}) > 95'
               instant: true
               refId: A
           - refId: C
@@ -332,8 +332,8 @@ groups:
         for: 10m
         labels: { severity: warning, component: node }
         annotations:
-          summary: "{{ $labels.instance }} memory > 90%"
-          description: "Available memory below 10% on {{ $labels.instance }} for 10m. Usage: {{ printf \"%.1f\" $values.A.Value }}%."
+          summary: "{{ $labels.instance }} memory > 95%"
+          description: "Available memory below 5% on {{ $labels.instance }} for 10m. Usage: {{ printf \"%.1f\" $values.A.Value }}%. (Jetson runs at 90% by design — only fire above 95.)"
 
       - uid: alert-node-disk-low
         title: NodeDiskLow

--- a/deployments/infrastructure/services/grafana/alert-rules.yaml
+++ b/deployments/infrastructure/services/grafana/alert-rules.yaml
@@ -399,3 +399,36 @@ groups:
         annotations:
           summary: "Memex log error burst"
           description: ">20 error-like log lines in 5m, sustained 10m. Inspect Memex alloc logs."
+
+      - uid: alert-scrape-job-missing
+        title: ScrapeJobMissing
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: 'absent(up{job="node"}) or absent(up{job="nomad"}) or absent(up{job="consul"}) or absent(up{job="haproxy"}) or absent(up{job="postgres"}) or absent(up{job="minio"}) or absent(up{job="prometheus"})'
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last, params: [] }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 10m
+        labels: { severity: critical, component: prometheus }
+        annotations:
+          summary: "Scrape job '{{ $labels.job }}' has zero targets"
+          description: "The '{{ $labels.job }}' Prometheus scrape job is missing entirely (no targets, or all dropped before scrape). This silently disables all per-target down-alerts for that job. Inspect http://192.168.2.47:9090/targets."

--- a/deployments/infrastructure/variables.tf
+++ b/deployments/infrastructure/variables.tf
@@ -12,3 +12,9 @@ variable "gcs_backup_bucket" {
   description = "GCS bucket name for off-site backups"
   type        = string
 }
+
+variable "telegram_alert_chat_id" {
+  description = "Telegram chat ID that receives Grafana alerts (reuses Hermes bot token from Vault)."
+  type        = string
+  default     = "10650075"
+}


### PR DESCRIPTION
## Summary
- 13 Grafana-managed alert rules (node down, scrape job missing, scheduler health, service availability, resource saturation, Memex log error burst) wired to a Telegram contact point reusing the Hermes bot
- Severity-tiered notification policy (critical: 30m repeat; warning: 4h repeat) with one root contact point and severity-keyed child routes
- Grafana 11.5 file-based provisioning at `/etc/grafana/provisioning/alerting/` (contactpoints, policies, templates, rules) — atomic and declarative

## How it ships
- Tested end-to-end: deployed against the live cluster, verified all 13 rules load, contact point + policy register, and a real Telegram message delivered to chat `10650075` from `@OrangeStreetHermesBot`
- The first deploy of v1 alerting flooded Telegram with false positives (every `up{job="X"} == 0` query returned NoData when healthy, and `noDataState: Alerting` interpreted that as "fire critical"). Fixed in `0f6da3c` by flipping all rules to `noDataState: OK` — empty result = healthy
- The fix introduced a coverage gap (silent if a scrape job entirely vanishes), closed in `cb2a0a5` by adding a `ScrapeJobMissing` rule using `absent(up{job="X"})` OR'd across all 7 jobs

## Prerequisite (one-time, manual)
Bot token must be populated in Vault at the Grafana-namespaced path. Nomad's per-job Vault policy isolates each job to its own prefix, so Grafana cannot read `secret/default/hermes/*`:
```
vault kv put secret/default/grafana/telegram bot_token=<same-token-as-hermes>
```

## Test plan
- [x] All 13 rules visible at http://192.168.2.47:3000/alerting/list, state Normal
- [x] Contact point `telegram-default` and the two-route severity policy show under Contact points / Notification policies
- [x] No false-positive critical alerts within 30 minutes of deploy on a healthy cluster
- [x] Verify metric names exist post-deploy: `nomad_client_allocations_blocked`, `pg_up`, `haproxy_process_start_time_seconds`, `minio_cluster_nodes_offline_total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
