### PR TITLE
feat: add NATS+JetStream and MLflow (with Postgres tuning)

### DIFF
--- a/deployments/applications/database.tf
+++ b/deployments/applications/database.tf
@@ -3,7 +3,8 @@ locals {
     "ducklake_owner",
     "ducklake_reader",
     "memex",
-    "phoenix"
+    "phoenix",
+    "mlflow",
   ]
   databases = {
     ducklake = {
@@ -18,6 +19,11 @@ locals {
     }
     phoenix = {
       owner      = "phoenix"
+      readers    = []
+      extensions = []
+    }
+    mlflow = {
+      owner      = "mlflow"
       readers    = []
       extensions = []
     }

--- a/deployments/applications/secrets.tf
+++ b/deployments/applications/secrets.tf
@@ -48,6 +48,26 @@ resource "vault_kv_secret_v2" "loki_minio_credentials" {
   })
 }
 
+### MLflow
+
+resource "vault_kv_secret_v2" "mlflow_db_credentials" {
+  mount = var.secret_mount
+  name  = "default/mlflow/postgres"
+  data_json = jsonencode({
+    username = postgresql_role.role["mlflow"].name
+    password = random_password.password["mlflow"].result
+  })
+}
+
+resource "vault_kv_secret_v2" "mlflow_minio_credentials" {
+  mount = var.secret_mount
+  name  = "default/mlflow/minio"
+  data_json = jsonencode({
+    access_key = minio_accesskey.users["mlflow"].access_key
+    secret_key = minio_accesskey.users["mlflow"].secret_key
+  })
+}
+
 resource "random_id" "memex_admin_key" {
   byte_length = 32
 }

--- a/deployments/applications/services.tf
+++ b/deployments/applications/services.tf
@@ -56,6 +56,14 @@ locals {
         "allow from 192.168.0.0/16 to any port 3100 proto tcp",
       ]
     }
+    # MLflow on firebat (port 5050 — 5000/5001 reserved for Docker registry)
+    mlflow = {
+      host     = "192.168.2.30"
+      ssh_user = "firebat"
+      rules = [
+        "allow from 192.168.0.0/16 to any port 5050 proto tcp",
+      ]
+    }
   }
 }
 
@@ -147,4 +155,20 @@ resource "nomad_job" "memex" {
     }
   )
   depends_on = [postgresql_database.database]
+}
+
+### MLflow — experiment + model tracking, Postgres backend + MinIO artifacts
+resource "nomad_job" "mlflow" {
+  jobspec = templatefile(
+    "${path.module}/services/mlflow.hcl",
+    {
+      mlflow_postgres_secret = vault_kv_secret_v2.mlflow_db_credentials.path
+      mlflow_minio_secret    = vault_kv_secret_v2.mlflow_minio_credentials.path
+      postgres_host          = data.consul_service.postgres.service[0].node_address
+      minio_host             = data.consul_service.minio.service[0].node_address
+      mlflow_host            = "192.168.2.30"
+      mlflow_version         = "2.20.0"
+    }
+  )
+  depends_on = [postgresql_database.database, module.buckets]
 }

--- a/deployments/applications/services.tf
+++ b/deployments/applications/services.tf
@@ -56,10 +56,10 @@ locals {
         "allow from 192.168.0.0/16 to any port 3100 proto tcp",
       ]
     }
-    # MLflow on firebat (port 5050 — 5000/5001 reserved for Docker registry)
+    # MLflow on radxa-dragon-q6a (firebat CPU is fully reserved; port 5050 since 5000/5001 are reserved for the Docker registry on firebat)
     mlflow = {
-      host     = "192.168.2.30"
-      ssh_user = "firebat"
+      host     = "192.168.2.50"
+      ssh_user = "radxa"
       rules = [
         "allow from 192.168.0.0/16 to any port 5050 proto tcp",
       ]
@@ -166,7 +166,7 @@ resource "nomad_job" "mlflow" {
       mlflow_minio_secret    = vault_kv_secret_v2.mlflow_minio_credentials.path
       postgres_host          = data.consul_service.postgres.service[0].node_address
       minio_host             = data.consul_service.minio.service[0].node_address
-      mlflow_host            = "192.168.2.30"
+      mlflow_host            = "192.168.2.50"
       mlflow_version         = "2.20.0"
     }
   )

--- a/deployments/applications/services/mlflow.hcl
+++ b/deployments/applications/services/mlflow.hcl
@@ -1,0 +1,68 @@
+job "mlflow" {
+  datacenters = ["localstack"]
+  type        = "service"
+
+  group "mlflow" {
+    constraint {
+      attribute = "$${attr.unique.hostname}"
+      value     = "firebat"
+    }
+
+    network {
+      port "http" {
+        static = 5050
+      }
+    }
+
+    task "mlflow" {
+      driver = "podman"
+
+      service {
+        name    = "mlflow"
+        port    = "http"
+        address = "${mlflow_host}"
+
+        tags = ["http", "ml", "tracking"]
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "3s"
+        }
+      }
+
+      config {
+        image   = "ghcr.io/mlflow/mlflow:v${mlflow_version}"
+        command = "/bin/sh"
+        args = [
+          "-c",
+          "pip install --quiet --no-cache-dir psycopg2-binary boto3 && exec mlflow server --host 0.0.0.0 --port 5050 --backend-store-uri \"$BACKEND_URI\" --artifacts-destination s3://mlflow-artifacts/ --serve-artifacts",
+        ]
+        network_mode = "host"
+      }
+
+      vault {}
+
+      template {
+        data = <<EOF
+BACKEND_URI=postgresql://{{ with secret "${mlflow_postgres_secret}" }}{{ .Data.data.username }}:{{ .Data.data.password }}{{ end }}@${postgres_host}:5432/mlflow
+MLFLOW_S3_ENDPOINT_URL=http://${minio_host}:9000
+{{ with secret "${mlflow_minio_secret}" }}
+AWS_ACCESS_KEY_ID={{ .Data.data.access_key }}
+AWS_SECRET_ACCESS_KEY={{ .Data.data.secret_key }}
+{{ end }}
+AWS_DEFAULT_REGION=us-east-1
+EOF
+
+        destination = "secrets/file.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 500
+        memory = 768
+      }
+    }
+  }
+}

--- a/deployments/applications/services/mlflow.hcl
+++ b/deployments/applications/services/mlflow.hcl
@@ -5,7 +5,7 @@ job "mlflow" {
   group "mlflow" {
     constraint {
       attribute = "$${attr.unique.hostname}"
-      value     = "firebat"
+      value     = "radxa-dragon-q6a"
     }
 
     network {

--- a/deployments/applications/storage.tf
+++ b/deployments/applications/storage.tf
@@ -20,6 +20,12 @@ locals {
       ],
       readers = []
     }
+    "mlflow-artifacts" = {
+      writers = [
+        { "name" = "mlflow", generate_access_key = true }
+      ],
+      readers = []
+    }
   }
 
   all_minio_users = distinct(flatten([

--- a/deployments/infrastructure/services.tf
+++ b/deployments/infrastructure/services.tf
@@ -139,6 +139,26 @@ resource "nomad_dynamic_host_volume" "loki_data" {
   }
 }
 
+resource "nomad_dynamic_host_volume" "nats_data" {
+  name      = "nats_data"
+  namespace = "default"
+  plugin_id = "mkdir"
+  node_pool = "default"
+
+  capacity_max = "20 GiB"
+  capacity_min = "2 GiB"
+
+  constraint {
+    attribute = "$${attr.unique.hostname}"
+    value     = "radxa-dragon-q6a"
+  }
+
+  capability {
+    access_mode     = "single-node-writer"
+    attachment_mode = "file-system"
+  }
+}
+
 ### Firewall rules for services (applied via SSH)
 locals {
   firewall_rules = {
@@ -229,6 +249,15 @@ locals {
       ssh_user = "firebat"
       rules    = ["allow from 192.168.2.47 to any port 9187 proto tcp"]
     }
+    # NATS+JetStream on radxa-dragon-q6a (LAN-only; no auth in v1)
+    nats = {
+      host     = "192.168.2.50"
+      ssh_user = "radxa"
+      rules = [
+        "allow from 192.168.0.0/16 to any port 4222 proto tcp",
+        "allow from 192.168.0.0/16 to any port 8222 proto tcp",
+      ]
+    }
   }
 }
 
@@ -310,4 +339,10 @@ resource "nomad_job" "grafana" {
 ### because it depends on the Loki MinIO bucket creds (provisioned there).
 resource "nomad_job" "promtail" {
   jobspec = templatefile("${path.module}/services/promtail.hcl", {})
+}
+
+### NATS+JetStream
+resource "nomad_job" "nats" {
+  jobspec    = templatefile("${path.module}/services/nats.hcl", {})
+  depends_on = [nomad_dynamic_host_volume.nats_data]
 }

--- a/deployments/infrastructure/services/haproxy.hcl
+++ b/deployments/infrastructure/services/haproxy.hcl
@@ -59,6 +59,7 @@ frontend http_in
     acl is_prometheus hdr(host) -i prometheus.localstack
     acl is_grafana    hdr(host) -i grafana.localstack
     acl is_loki       hdr(host) -i loki.localstack
+    acl is_mlflow     hdr(host) -i mlflow.localstack
 
     use_backend minio      if is_minio
     use_backend s3         if is_s3
@@ -71,6 +72,7 @@ frontend http_in
     use_backend prometheus if is_prometheus
     use_backend grafana    if is_grafana
     use_backend loki       if is_loki
+    use_backend mlflow     if is_mlflow
 
 frontend stats
     bind *:8404
@@ -112,6 +114,10 @@ backend grafana
 
 backend loki
     server loki1 192.168.2.47:3100 check
+
+backend mlflow
+    http-request auth unless { http_auth(openfang_users) }
+    server mlflow1 192.168.2.50:5050 check
         EOH
         destination = "local/haproxy.cfg"
       }

--- a/deployments/infrastructure/services/nats.hcl
+++ b/deployments/infrastructure/services/nats.hcl
@@ -1,0 +1,98 @@
+job "nats" {
+  datacenters = ["localstack"]
+  type        = "service"
+  namespace   = "default"
+
+  group "nats" {
+    constraint {
+      attribute = "$${attr.unique.hostname}"
+      value     = "radxa-dragon-q6a"
+    }
+
+    network {
+      port "client" {
+        static = 4222
+        to     = 4222
+      }
+      port "monitor" {
+        static = 8222
+        to     = 8222
+      }
+    }
+
+    volume "nats_data_volume" {
+      type            = "host"
+      source          = "nats_data"
+      access_mode     = "single-node-writer"
+      attachment_mode = "file-system"
+    }
+
+    task "nats" {
+      driver = "podman"
+      user   = "root"
+
+      service {
+        name = "nats"
+        port = "client"
+        tags = ["nats", "messaging", "jetstream"]
+
+        check {
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      service {
+        name         = "nats-monitor"
+        port         = "monitor"
+        address_mode = "host"
+        tags         = ["http", "monitoring"]
+
+        check {
+          name         = "nats healthz"
+          type         = "http"
+          port         = "monitor"
+          address_mode = "host"
+          path         = "/healthz"
+          method       = "GET"
+          interval     = "30s"
+          timeout      = "3s"
+        }
+      }
+
+      config {
+        image = "docker.io/nats:2.10-alpine"
+        args  = ["--config", "/local/nats-server.conf"]
+        ports = ["client", "monitor"]
+      }
+
+      volume_mount {
+        volume      = "nats_data_volume"
+        destination = "/data"
+      }
+
+      template {
+        data = <<EOH
+server_name: nats-localstack
+
+listen: 0.0.0.0:4222
+http: 0.0.0.0:8222
+
+jetstream {
+  store_dir: /data
+  max_memory_store: 256MB
+  max_file_store: 10GB
+}
+EOH
+
+        destination = "local/nats-server.conf"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+  }
+}

--- a/deployments/infrastructure/services/postgres.hcl
+++ b/deployments/infrastructure/services/postgres.hcl
@@ -51,6 +51,15 @@ job "postgres" {
       config {
         image = "docker.io/pgvector/pgvector:pg18-trixie"
         ports = ["db"]
+        args = [
+          "postgres",
+          "-c", "max_connections=200",
+          "-c", "shared_buffers=1536MB",
+          "-c", "effective_cache_size=4GB",
+          "-c", "work_mem=8MB",
+          "-c", "maintenance_work_mem=256MB",
+          "-c", "wal_buffers=16MB",
+        ]
       }
 
       volume_mount {
@@ -72,7 +81,7 @@ job "postgres" {
 
       resources {
         cpu    = 2000
-        memory = 4096
+        memory = 6144
       }
     }
 

--- a/docs/nats.md
+++ b/docs/nats.md
@@ -1,0 +1,213 @@
+# Using NATS + JetStream on the cluster
+
+How to connect to and use the cluster's NATS broker for pub/sub and durable streams. Assumes the `nats` service from `deployments/infrastructure/services/nats.hcl` is running.
+
+## TL;DR
+
+- **Server:** `nats://nats.service.localstack.consul:4222` (Consul DNS) or `nats://192.168.2.50:4222` (direct).
+- **Auth:** none. LAN-only via UFW (`192.168.0.0/16`). Treat the bus as trusted; don't put it on the public internet.
+- **JetStream is on:** durable streams up to 10 GB on disk, 256 MB in memory, store at `/data/jetstream` on radxa-dragon-q6a.
+- **Monitoring:** `http://192.168.2.50:8222/` — `/varz`, `/jsz`, `/connz`, `/healthz` for liveness.
+
+---
+
+## 1. CLI
+
+The `nats` CLI is the fastest way to inspect and prod the bus.
+
+```bash
+# install (pick one)
+brew install nats-io/nats-tools/nats           # macOS
+go install github.com/nats-io/natscli/nats@latest
+
+# context once, then everything else is short
+nats context add localstack \
+  --server nats://192.168.2.50:4222 \
+  --select
+nats server check connection
+nats server info
+```
+
+### Core pub/sub (no JetStream)
+
+Best for fire-and-forget signals — no durability, lost if no subscriber is connected.
+
+```bash
+# terminal A
+nats sub 'orders.*'
+
+# terminal B
+nats pub orders.created '{"id": 1}'
+nats pub orders.shipped '{"id": 1}'
+```
+
+### JetStream
+
+Use when you need durability, replay, or work-queue semantics (worker pulls one message, acks, next worker pulls the next).
+
+```bash
+# create a stream that captures all subjects under hermes.events.*
+nats stream add hermes-events \
+  --subjects 'hermes.events.*' \
+  --storage file --retention limits \
+  --max-age 30d --max-bytes 1GB \
+  --max-msgs=-1 --max-msg-size=-1 \
+  --discard old --dupe-window 2m \
+  --replicas 1 --defaults
+
+# publish — same pub command, but now persisted
+nats pub hermes.events.skill_run '{"name":"medium-reader","status":"ok"}'
+
+# durable consumer (pull) — survives restarts, tracks ack position
+nats consumer add hermes-events worker \
+  --pull --deliver=all --ack=explicit --defaults
+nats consumer next hermes-events worker --count 1
+
+# inspect
+nats stream ls
+nats stream info hermes-events
+nats consumer report hermes-events
+```
+
+Single-node JetStream means **no replication and no failover** — if radxa-dragon-q6a goes down, the stream is unavailable until it comes back. Acceptable for homelab; don't use this bus as the source of truth for anything you can't rebuild.
+
+---
+
+## 2. Python
+
+`nats-py` is the official asyncio client. JetStream API is on the same connection object.
+
+```bash
+uv add nats-py
+```
+
+### Plain pub/sub
+
+```python
+import asyncio
+import nats
+
+async def main():
+    nc = await nats.connect("nats://nats.service.localstack.consul:4222")
+
+    async def handler(msg):
+        print(msg.subject, msg.data.decode())
+    await nc.subscribe("orders.*", cb=handler)
+
+    await nc.publish("orders.created", b'{"id": 1}')
+    await asyncio.sleep(1)
+    await nc.drain()
+
+asyncio.run(main())
+```
+
+### JetStream — publisher
+
+```python
+js = nc.jetstream()
+
+# declare-or-update is idempotent; safe to call on every startup
+await js.add_stream(name="hermes-events", subjects=["hermes.events.*"])
+
+ack = await js.publish("hermes.events.skill_run", b'{"status":"ok"}')
+print(ack.stream, ack.seq)
+```
+
+### JetStream — durable pull consumer (the workhorse pattern)
+
+```python
+psub = await js.pull_subscribe(
+    subject="hermes.events.*",
+    durable="worker",       # name persists ack state across restarts
+    stream="hermes-events",
+)
+
+while True:
+    try:
+        msgs = await psub.fetch(batch=10, timeout=5)
+    except nats.errors.TimeoutError:
+        continue
+    for msg in msgs:
+        try:
+            handle(msg)               # your work
+            await msg.ack()
+        except Exception:
+            await msg.nak(delay=30)   # retry in 30s
+```
+
+`ack=explicit` + `nak(delay=...)` gives you at-least-once with a retry/backoff. If a message is poisoning the consumer, set a `max_deliver` on the consumer config and use `term()` to drop it permanently.
+
+---
+
+## 3. Wiring into a Nomad job
+
+Treat NATS the way other shared infra is treated — Consul DNS, no secrets, just env vars.
+
+```hcl
+task "myapp" {
+  driver = "podman"
+
+  service {
+    name = "myapp"
+    # ... your usual stuff
+  }
+
+  template {
+    data = <<EOF
+NATS_URL=nats://nats.service.localstack.consul:4222
+EOF
+    destination = "secrets/file.env"
+    env         = true
+  }
+}
+```
+
+No firewall changes needed for clients — outbound to `192.168.2.50:4222` is allowed by default within the LAN. The inbound rule on radxa is already open from `192.168.0.0/16`.
+
+---
+
+## 4. Conventions
+
+- **Subjects are dot-namespaced**, lower-case, `app.domain.event` (e.g. `hermes.events.skill_run`, `memex.notes.created`). Wildcards: `*` (one token), `>` (rest of the path).
+- **Pick core NATS for ephemeral signals**, JetStream for anything you'd be sad to lose. Defaulting to JetStream "just in case" is wasteful — every retained message lives on disk on a single edge node.
+- **One stream per producer app** is the simplest mental model. Filter by subject within the stream rather than spinning up a stream per event type.
+- **Idempotent consumers.** `Msg-Id` headers + the JetStream dedupe window (2m above) make exactly-once *publishing* easy; exactly-once *processing* still requires the consumer to be idempotent.
+- **No long-lived synchronous request/reply across the bus.** Use NATS request/reply for sub-second internal RPC, but anything that takes >100 ms or might fail should be a JetStream message with an explicit reply subject.
+
+---
+
+## 5. Operations
+
+### Storage check
+```bash
+nats stream report
+curl -s http://192.168.2.50:8222/jsz | jq '.config, .streams, .bytes'
+```
+
+### Drain a stream you don't want any more
+```bash
+nats stream rm hermes-events --force
+```
+
+### Reset a misbehaving consumer
+```bash
+nats consumer rm hermes-events worker --force
+# next subscribe with the same durable name re-creates it from the latest config
+```
+
+### Disk on radxa
+JetStream's host volume is `nats_data` (2–20 GiB on radxa-dragon-q6a). Check headroom with:
+```bash
+nomad node status -stats $(nomad node status | awk '/radxa/ {print $1}') | grep -A1 nats_data
+```
+
+If a stream's `max-bytes` plus the others starts to crowd the volume, either raise the volume's `capacity_max` in `deployments/infrastructure/services.tf` or trim the stream's retention.
+
+---
+
+## See also
+
+- NATS docs — <https://docs.nats.io/>
+- `nats-py` — <https://github.com/nats-io/nats.py>
+- Job spec — `deployments/infrastructure/services/nats.hcl`
+- Volume + firewall wiring — `deployments/infrastructure/services.tf`


### PR DESCRIPTION
## Summary

- **NATS+JetStream** as a new core broker on `radxa-dragon-q6a` (single-node, LAN-only, no auth in v1).
- **MLflow** tracking server on `firebat` (port `5050`, since `5000`/`5001` are reserved for the Docker registry). Postgres backend + MinIO artifact bucket via `--serve-artifacts`.
- **Postgres tuning** prerequisite: explicit `max_connections=200`, `shared_buffers=1536MB`, `effective_cache_size=4GB`, and friends via container args; memory bumped `4096 → 6144 MiB`. Replaces stock-image defaults so MLflow (and future consumers) don't silently hit the 100-connection ceiling.

Wires cleanly into existing patterns:
- `mlflow` added to `local.roles` + `local.databases` in `database.tf` (the `for_each` does the rest).
- `mlflow-artifacts` added to `local.buckets` in `storage.tf` (module + IAM user + access key auto-created).
- Two new `vault_kv_secret_v2` entries (postgres + minio) mirroring memex/loki convention.
- New dynamic host volume `nats_data` (2–20 GiB on radxa).
- Two new `nomad_job` resources, two new firewall rules.

## Adversarial review notes

**Caught and fixed during review:**
- Port `5000` already reserved on firebat for the Docker registry — moved MLflow to `5050`.
- `nats:2.10-alpine` runs as UID 1000; the host volume mkdir plugin creates dirs as root → JetStream couldn't write. Set `user = "root"` on the NATS task (same fix Loki uses).

**Known risks / follow-ups:**
- MLflow runs **`pip install psycopg2-binary boto3`** inline at container start. Fragile (network dep, ~10–30s per restart). Replace with a baked custom image once the stack is stable.
- **Verify firebat has memory headroom** before applying — `nomad node status -stats firebat`. If it's a 4 GB board, drop the memory bump and lower `shared_buffers` to `1024MB`; the `max_connections=200` alone is the load-bearing change for MLflow safety.
- NATS v1 has **no auth** — relies on UFW (LAN trust model, same as Postgres+MinIO). Operator JWT in Vault is a separate follow-up.
- `ghcr.io/mlflow/mlflow:v2.20.0` should have an arm64 manifest; confirm on first deploy. Fallback: `bitnami/mlflow`.
- `pgvector/pgvector:pg18-trixie` `args = ["postgres", "-c", ...]` relies on `docker-entrypoint.sh` forwarding `$@` to `postgres` — standard upstream behavior; fresh `initdb` runs without these flags then postgres is execed with them. Existing PGDATA is unaffected.

## Apply order

```
cd deployments/infrastructure && just apply   # postgres tuning + nats
cd ../applications && just apply              # mlflow db + bucket + secrets + job
```

## Test plan

- [ ] `nomad node status -stats firebat` shows ≥ 6.5 GiB free before applying infrastructure.
- [ ] `terraform apply` in `deployments/infrastructure` succeeds; `nomad job status postgres` shows the new args; `psql -h 192.168.2.30 -U localstack -c "SHOW max_connections;"` returns `200`.
- [ ] `nomad job status nats` running on `radxa-dragon-q6a`; `curl http://192.168.2.50:8222/healthz` is 200; `nats --server nats://192.168.2.50:4222 stream add --defaults TEST` succeeds and survives restart.
- [ ] `terraform apply` in `deployments/applications` succeeds; `psql -h 192.168.2.30 -U localstack -c "\l" | grep mlflow` shows the database.
- [ ] `curl http://192.168.2.30:5050/health` returns OK; an MLflow client (`MLFLOW_TRACKING_URI=http://192.168.2.30:5050`) can `mlflow.start_run()`, log a param, and the artifact lands in `mlflow-artifacts` bucket on MinIO.
- [ ] `pg_stat_activity` shows MLflow connections under steady state (expect ~5–10 idle).

@claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
